### PR TITLE
修正YamlDatabaseAdapter.get(BukkitPositionInfo)呼叫鏈NPE

### DIFF
--- a/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/commands/utility/DebugCommand.java
+++ b/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/commands/utility/DebugCommand.java
@@ -59,6 +59,7 @@ public class DebugCommand implements SubCommand {
 
         sender.sendMessage(Lang.get("command.debug.status-header"));
         sender.sendMessage(Lang.get("command.debug.queue-size", NatureRevivePlugin.queue.size()));
+        sender.sendMessage(Lang.get("command.debug.in-flight-size", NatureRevivePlugin.regenInFlight.size()));
 
         if ((sender instanceof Player player)) {
             BukkitPositionInfo positionInfo = NatureRevivePlugin.databaseConfig.get(player.getLocation());

--- a/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/config/adapters/YamlDatabaseAdapter.java
+++ b/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/config/adapters/YamlDatabaseAdapter.java
@@ -39,7 +39,7 @@ public class YamlDatabaseAdapter implements DatabaseConfig {
     }
 
     public BukkitPositionInfo get(BukkitPositionInfo positionInfo) {
-        return (BukkitPositionInfo) configuration.get(safeFormatLocation(positionInfo), positionInfo);
+        return (BukkitPositionInfo) configuration.get(safeFormatLocation(positionInfo));
     }
 
     public List<BukkitPositionInfo> values() {

--- a/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/config/adapters/YamlDatabaseAdapter.java
+++ b/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/config/adapters/YamlDatabaseAdapter.java
@@ -27,7 +27,7 @@ public class YamlDatabaseAdapter implements DatabaseConfig {
     }
 
     public void set(BukkitPositionInfo positionInfo) {
-        configuration.set(formatLocation(positionInfo.getLocation()), positionInfo);
+        configuration.set(safeFormatLocation(positionInfo), positionInfo);
     }
 
     public void unset(BukkitPositionInfo positionInfo) {
@@ -39,7 +39,7 @@ public class YamlDatabaseAdapter implements DatabaseConfig {
     }
 
     public BukkitPositionInfo get(BukkitPositionInfo positionInfo) {
-        return (BukkitPositionInfo) configuration.get(formatLocation(positionInfo.getLocation()), positionInfo);
+        return (BukkitPositionInfo) configuration.get(safeFormatLocation(positionInfo), positionInfo);
     }
 
     public List<BukkitPositionInfo> values() {

--- a/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/managers/ChunkRegeneration.java
+++ b/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/managers/ChunkRegeneration.java
@@ -86,6 +86,12 @@ public class ChunkRegeneration {
         List<NbtWithPos> nbtWithPos = new ArrayList<>();
 
         World world = location.getWorld();
+
+        if (world == null) {
+            finalizeRegen(bukkitPositionInfo.getWorldName(), bukkitPositionInfo.getX(), bukkitPositionInfo.getZ());
+            return;
+        }
+
         // Thanks to xuan
         int centerX = location.getBlockX() >> 4;
         int centerZ = location.getBlockZ() >> 4;

--- a/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/tasks/regen/RegenTask.java
+++ b/naturerevive-spigot/src/main/java/engineer/skyouo/plugins/naturerevive/spigot/tasks/regen/RegenTask.java
@@ -27,12 +27,17 @@ public class RegenTask implements Task {
         for (int i = 0; i < readonlyConfig.taskPerProcess && queue.hasNext(); i++) {
             BukkitPositionInfo task = queue.pop();
 
-            if (!readonlyConfig.allowedWorld.isEmpty() && !readonlyConfig.allowedWorld.contains(task.getLocation().getWorld().getName())) {
+            if (!readonlyConfig.allowedWorld.isEmpty() && !readonlyConfig.allowedWorld.contains(task.getWorldName())) {
                 regenInFlight.remove(task.getChunkKey());
                 continue;
             }
 
-            if (readonlyConfig.ignoredWorld.contains(task.getLocation().getWorld().getName())) {
+            if (readonlyConfig.ignoredWorld.contains(task.getWorldName())) {
+                regenInFlight.remove(task.getChunkKey());
+                continue;
+            }
+
+            if (Bukkit.getWorld(task.getWorldName()) == null) {
                 regenInFlight.remove(task.getChunkKey());
                 continue;
             }

--- a/naturerevive-spigot/src/main/resources/lang/en_US.yml
+++ b/naturerevive-spigot/src/main/resources/lang/en_US.yml
@@ -21,6 +21,7 @@ command:
   debug:
     status-header: "NatureRevive status:\n"
     queue-size: "- Queue size: %s"
+    in-flight-size: "- In-flight marker count (regenInFlight): %s"
     chunk-regen-date: "- Regeneration date of the chunk you are standing on: %s"
     chunk-queue-position: "- Queue position of the chunk you are standing on: %s"
     queue-position-none: "none"

--- a/naturerevive-spigot/src/main/resources/lang/zh_TW.yml
+++ b/naturerevive-spigot/src/main/resources/lang/zh_TW.yml
@@ -19,6 +19,7 @@ command:
   debug:
     status-header: "NatureRevive 運行狀態：\n"
     queue-size: "- 隊列大小：%s"
+    in-flight-size: "- 執行中標記數量（regenInFlight）：%s"
     chunk-regen-date: "- 您腳下的 chunk 之重生日期：%s"
     chunk-queue-position: "- 您腳下的 chunk 於隊列的位置為：%s"
     queue-position-none: "無"


### PR DESCRIPTION
修正前遇到的問題，改用safeFormatLocation避免location.getWorld()回傳null

[12:46:39] [Server thread/ERROR]: Could not pass event ChunkLoadEvent to NatureRevive v2.3.5
java.lang.NullPointerException: Cannot invoke "org.bukkit.World.getName()" because the return value of "org.bukkit.Location.getWorld()" is null
	at NatureRevive-2.3.5.jar//engineer.skyouo.plugins.naturerevive.spigot.config.adapters.YamlDatabaseAdapter.formatLocation(YamlDatabaseAdapter.java:69) ~[?:?]
	at NatureRevive-2.3.5.jar//engineer.skyouo.plugins.naturerevive.spigot.config.adapters.YamlDatabaseAdapter.get(YamlDatabaseAdapter.java:42) ~[?:?]
	at NatureRevive-2.3.5.jar//engineer.skyouo.plugins.naturerevive.spigot.listeners.ChunkRelatedEventListener.onChunkLoadEvent(ChunkRelatedEventListener.java:187) ~[?:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-26.1.2.build.72-stable.jar:?]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[paper-api-26.1.2.build.72-stable.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-26.1.2.build.72-stable.jar:?]
	at net.minecraft.world.level.chunk.LevelChunk.loadCallback(LevelChunk.java:646) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at ca.spottedleaf.moonrise.paper.util.BaseChunkSystemHooks.onChunkBorder(BaseChunkSystemHooks.java:95) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.NewChunkHolder.handleFullStatusChange(NewChunkHolder.java:1253) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkHolderManager.processPendingFullUpdate(ChunkHolderManager.java:1492) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkHolderManager.processTicketUpdates(ChunkHolderManager.java:1452) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at net.minecraft.server.level.ServerChunkCache.runDistanceManagerUpdates(ServerChunkCache.java:438) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at net.minecraft.server.level.ServerChunkCache$MainThreadExecutor.pollTask(ServerChunkCache.java:828) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at net.minecraft.server.level.ServerChunkCache.pollTask(ServerChunkCache.java:434) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at FastAsyncWorldEdit-Paper-2.15.3.jar//com.sk89q.worldedit.bukkit.adapter.impl.fawe.v26_1.regen.PaperweightRegen.runTasks(PaperweightRegen.java:102) ~[?:?]
	at FastAsyncWorldEdit-Paper-2.15.3.jar//com.fastasyncworldedit.bukkit.adapter.Regenerator.lambda$copyToWorld$0(Regenerator.java:109) ~[?:?]
	at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1793) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1646) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:444) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1704) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1374) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:304) ~[paper-26.1.2.jar:26.1.2-72-1a6b910]
	at java.base/java.lang.Thread.run(Thread.java:1516) ~[?:?]
